### PR TITLE
Use running process to execute child scripts

### DIFF
--- a/script/update.js
+++ b/script/update.js
@@ -4,7 +4,7 @@ const path = require('path')
 const execFileSync = require('child_process').execFileSync
 
 console.log('Downloading metadata')
-execFileSync(path.join(__dirname, 'download-metadata.js'), {stdio: 'inherit'})
+execFileSync(process.execPath, [path.join(__dirname, 'download-metadata.js')], {stdio: 'inherit'})
 
 console.log('Cloning packages')
-execFileSync(path.join(__dirname, 'clone-packages.js'), {stdio: 'inherit'})
+execFileSync(process.execPath, [path.join(__dirname, 'clone-packages.js')], {stdio: 'inherit'})


### PR DESCRIPTION
On systems that don't support sha-bang (Windows), this allows the update.js script to run the child processes using the Node.js that it was executed under.